### PR TITLE
Fix missing dependencies in requirements.txt

### DIFF
--- a/Code/requirements.txt
+++ b/Code/requirements.txt
@@ -8,3 +8,5 @@ fastapi
 librosa
 pydantic
 soundfile
+uvicorn
+matplotlib


### PR DESCRIPTION
Fixes #18 by adding `uvicorn` and `matplotlib` to `requirements.txt`.