### PR TITLE
Fix sample rate mismatch in MelSpectrogram transform

### DIFF
--- a/Code/main.py
+++ b/Code/main.py
@@ -23,7 +23,7 @@ class AudioProcessor:
     def __init__(self):
         self.transform = nn.Sequential(
             T.MelSpectrogram(
-                sample_rate=22050, n_fft=1024, hop_length=512, n_mels=128, f_min=0, f_max=11025
+                sample_rate=44100, n_fft=1024, hop_length=512, n_mels=128
             ),
             T.AmplitudeToDB()
         )

--- a/Code/train.py
+++ b/Code/train.py
@@ -210,7 +210,7 @@ def train():
 
     train_transform = nn.Sequential(
 
-        T.MelSpectrogram(sample_rate=22050, n_fft=1024, hop_length=512, n_mels=128),
+        T.MelSpectrogram(sample_rate=44100, n_fft=1024, hop_length=512, n_mels=128),
 
         T.AmplitudeToDB(),
 
@@ -223,7 +223,7 @@ def train():
 
     val_transform = nn.Sequential(
 
-        T.MelSpectrogram(sample_rate=22050, n_fft=1024, hop_length=512, n_mels=128),
+        T.MelSpectrogram(sample_rate=44100, n_fft=1024, hop_length=512, n_mels=128),
 
         T.AmplitudeToDB()
 


### PR DESCRIPTION
Fixes #21 by updating `sample_rate` to `44100` in the MelSpectrogram transforms to match the dataset's native sampling rate.